### PR TITLE
[add] modelExporters 

### DIFF
--- a/.github/workflows/fullTest.yml
+++ b/.github/workflows/fullTest.yml
@@ -20,7 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           python -m pip install wheel flask pytest pytest-cov
-          python -m pip install -e .
+          python -m pip install -e ".[dev]"
           
       - name: Download Models
         run: python -c "import pysipfenn; c = pysipfenn.Calculator(); c.downloadModels(); c.loadModels();"

--- a/.github/workflows/fullTest.yml
+++ b/.github/workflows/fullTest.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           python -m pip install wheel flask pytest pytest-cov
-          python -m pip install -e .
+          python -m pip install -e ".[dev]"
       - name: Download Models
         run: python -c "import pysipfenn; c = pysipfenn.Calculator(); c.downloadModels(); c.loadModels();"
            
@@ -78,7 +78,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           python -m pip install wheel flask pytest pytest-cov
-          python -m pip install -e .
+          python -m pip install -e ".[dev]"
       - name: Download Models
         run: python -c "import pysipfenn; c = pysipfenn.Calculator(); c.downloadModels(); c.loadModels();"
            

--- a/README.md
+++ b/README.md
@@ -14,22 +14,21 @@
 
 ![GitHub last commit (by committer)](https://img.shields.io/github/last-commit/PhasesResearchLab/pysipfenn?label=Last%20Commit)
 ![GitHub Release Date - Published_At](https://img.shields.io/github/release-date/PhasesResearchLab/pysipfenn?label=Last%20Release)
-![GitHub commits since tagged version](https://img.shields.io/github/commits-since/PhasesResearchLab/pysipfenn/v0.12.0?color=g)
+![GitHub commits since tagged version](https://img.shields.io/github/commits-since/PhasesResearchLab/pysipfenn/v0.13.0?color=g)
 ![GitHub issues](https://img.shields.io/github/issues/PhasesResearchLab/pysipfenn)
 
 [![DOI](https://img.shields.io/badge/DOI-10.1016%2Fj.commatsci.2022.111254-blue)](https://doi.org/10.1016/j.commatsci.2022.111254)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7373089.svg)](https://doi.org/10.5281/zenodo.7373089)
 
 ### Major News
-
-- **(v.12.2)** The license has been changed to LGPLv3 to allow for integration with proprietary software developed
+- **(v0.13.0)** Model exports are now effortless the new `pysipfenn.core.modelExporters` module, which also allows
+users to reduce models to FP16 precision or simplify model structure. It supports ONNX, PyTorch, and CoreML formats. The
+latter allows use of highly efficient Neural Engine on all modern Apple devices. Note that to use these features, you
+need to install additional dependencies with `pip install pysipfenn[dev]`.
+- **(v0.12.2)** The license has been changed to LGPLv3 to allow for integration with proprietary software developed
 by CALPHAD community, while supporting the development of new pySIPFENN features for all users. Many thanks to our colleagues from 
 [GTT-Technologies](https://gtt-technologies.de) and other participants of [50th CALPHAD 2023 conference in Boston](https://calphad.org/calphad-2023) for fruitful discussions.
-- **(v.12.0)** Official Python 3.11 support. 
-- **(v.12.0)** Automated matrix-testing on Linux / Mac / Windows with Python 3.9 / 3.10 / 3.11 through GitHub Actions CLI
-and test coverage report through Codecov. Tests are also generally improved and more extensive.
-- **(v0.11.0)** Some common questions are now addressed in the [documentation FAQ section](https://pysipfenn.readthedocs.io/en/stable/faq.html).
-- **(v0.11.0)** The model downloads from Zenodo are now multithreaded and are 15 times faster.
+- **(v0.12.0)** Official Python 3.11 support.
 - **(March 2023 Workshop)** We would like to thank all of our amazing attendees for making our workshop, co-organized with the
 [Materials Genome Foundation](https://materialsgenomefoundation.org), such a success! Over 100 of you simultaneously followed
 all exercises and, at the peak, we loaded over 1,200GB of models into the HPC's RAM. At this point, we would also like to 
@@ -125,3 +124,13 @@ Then, move to the pySIPFENN folder and install in editable (`-e`) mode
     cd pySIPFENN
     pip install -e .
 
+### Developer Install
+
+If you want to utilize pySIPFENN beyond its core functionalities, for instance, to train new models on custom datasets
+or to export models in different formats or precisions, you need to install additional dependencies. This can be done
+by installing the `dev` extras with
+
+    pip install pysipfenn[dev]
+
+> Note: If you are using MacOS zsh shell, you may need to enclose the `dev` extras in quotes like 
+> `pip install "pysipfenn[dev]"` or `pip install ".[dev]"`.

--- a/docs/exportingmodels.md
+++ b/docs/exportingmodels.md
@@ -1,0 +1,128 @@
+# Exporting pySIPFENN Models
+
+## General Information
+
+Whether you are the end-user of ML models and you want to integrate them into some other software that requires a
+specific format, or you are a developer who is modifying pySIPFENN models to predict formation energy resulting from 
+some particular DFT settings/pseudopotentials, or you retrain them on entirely different properties, you will probably need to export
+the models at some point. This page provides information on how to do that using the 3 exporter classes we provide
+in the `pysipfenn/core/modelExporters.py` module. Their API is very high-level and simple to use, so the process 
+should be straightforward.
+
+Please be aware that to use these exporters, you will need to install additional dependencies by installing the `dev`
+extras with
+
+    pip install "pysipfenn[dev]"
+
+or for development installation
+
+    pip install ".[dev]"
+
+
+## ONNXExporter
+
+The `ONNXExporter` class is used to export pySIPFENN models to the [ONNX](https://onnx.ai/) format. This is also the
+same format they are shipped in by us! The reason we implemented this exporter is that:
+1. Within pySIPFENN, models are actually stored as PyTorch models, and if they are modified, they need to be converted to 
+ONNX format again. 
+2. This exporter allows you to export models in different precision (float16) using its `toFP16` method. This is useful
+if you want to use the models on devices with limited memory, such as mobile phones or embedded devices.
+3. This exporter also allows you to simplify the model through the recent ONNX Optimizer package implementation, which 
+could improve model performance and reduce its size.
+
+To get started, you should take an initialized Calculator object and pass it to the exporter.
+
+    from pysipfenn import ONNXExporter
+    from pysipfenn import Calculator
+    
+    c = Calculator()
+    onnx_exporter = ONNXExporter(c)
+
+and then simply 
+
+    onnx_exporter.export("MyModelNameGoesHere")
+
+or to export all models in `c` at once
+
+    onnx_exporter.exportAll()
+
+and you should see new files like `MyModelNameGoesHere.onnx` in the current working directory. 
+
+If you want to export the 
+model in float16 precision, before you call `export` method, you should call
+
+    onnx_exporter.toFP16("MyModelNameGoesHere")
+
+or to convert all models in `c` at once
+
+    onnx_exporter.toFP16All()
+
+and similarly for simplification
+
+    onnx_exporter.simplify("MyModelNameGoesHere")
+
+or
+
+    onnx_exporter.simplifyAll()
+
+To summarize, if you want to export all models in `c` in float16 precision and simplified, you can do it with
+
+    from pysipfenn import ONNXExporter
+    from pysipfenn import Calculator
+    
+    c = Calculator()
+    onnx_exporter = ONNXExporter(c)
+    onnx_exporter.simplifyAll()
+    onnx_exporter.toFP16All()
+    onnx_exporter.exportAll()
+
+and you should see new files like `MyModelNameGoesHere_simplified_fp16.onnx` in the current working directory.
+
+
+## PyTorch
+
+This is the simplest of the export methods because, as mentioned in [ONNXExporter](#onnxexporter) section, pySIPFENN 
+models are already stored as PyTorch models; therefore, no conversion is needed. You can use it by simply calling 
+
+    from pysipfenn import PyTorchExporter
+    from pysipfenn import Calculator
+    
+    c = Calculator()
+    torch_exporter = PyTorchExporter(c)
+    torch_exporter.export("MyModelNameGoesHere")
+
+or to export all models in `c` at once, replace the last line with
+    
+    torch_exporter.exportAll()
+
+and you should see new files like `MyModelNameGoesHere.pt` in the current working directory.
+
+
+## CoreML
+
+CoreML is a format developed by Apple for use in their devices, where it provides the most seamless integration with
+existing apps and can harvest very efficient Neural Engine hardware acceleration. At the same time, it can be used on
+other platforms as well, such as Linux or Windows, through [coremltools](https://coremltools.readme.io/docs) toolset
+from Apple used by this exporter.
+
+Note that under the hood, CoreML uses the float16 precision, so the model predictions will numerically match those
+exported with [ONNXExporter](#onnxexporter) in float16 precision rather than the default pySIPFENN models. This can
+be useful if you want to use the models on devices with limited memory, such as mobile phones or embedded devices, and 
+generally should not significantly affect the accuracy of the predictions.
+
+You can use it by simply calling 
+
+    from pysipfenn import CoreMLExporter
+    from pysipfenn import Calculator
+    
+    c = Calculator()
+    coreml_exporter = CoreMLExporter(c)
+    coreml_exporter.export("MyModelNameGoesHere")
+
+or to export all models in `c` at once, replace the last line with
+
+    coreml_exporter.exportAll()
+
+and you should see new files like `MyModelNameGoesHere.mlpackage` in the current working directory. If you are on MacOS and
+have XCode installed, you can double-click on it to evaluate its integrity and benchmark its performance.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -116,6 +116,7 @@ Index
 
 .. toctree::
    install
+   exportingmodels
    faq
    source/pysipfenn
    examples/sipfenn_examples

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ pySIPFENN
     :alt: GitHub Release Date - Published_At
     :target: https://github.com/PhasesResearchLab/pySIPFENN/releases
 
-.. |GitHub commits since tagged version| image:: https://img.shields.io/github/commits-since/PhasesResearchLab/pysipfenn/v0.12.0?color=g
+.. |GitHub commits since tagged version| image:: https://img.shields.io/github/commits-since/PhasesResearchLab/pysipfenn/v0.13.0?color=g
     :alt: GitHub commits since tagged version
     :target: https://codecov.io/gh/PhasesResearchLab/pySIPFENN
 
@@ -81,6 +81,10 @@ is given in
 
 News
 ----
+-  **(v0.13.0)** Model exports are now effortless the new `pysipfenn.core.modelExporters` module, which also allows
+   users to reduce models to FP16 precision or simplify model structure. It supports ONNX, PyTorch, and CoreML formats. The
+   latter allows use of highly efficient Neural Engine on all modern Apple devices. Note that to use these features, you
+   need to install additional dependencies with `pip install pysipfenn[dev]`
 -  **(v.12.2)** The license has been changed to LGPLv3 to allow for integration with proprietary software developed
    by CALPHAD community, while supporting the development of new pySIPFENN features for all users. Many thanks to our colleagues from
    `GTT-Technologies <https://gtt-technologies.de>`__ and

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,7 @@
 # Install pySIPFENN
 
+## Regular Install
+
 Installing pySIPFENN is simple and easy utilizing either **PyPI** package repository or cloning from 
 [**GitHub**](https://git.pysipfenn.org).
 While not required, it is recommended to first set up a virtual environment using venv or Conda. This ensures that 
@@ -27,7 +29,7 @@ Then, move to the pySIPFENN folder and install in editable (`-e`) mode
     cd pySIPFENN
     pip install -e .
 
-# Developer Install
+## Developer Install
 
 If you want to utilize pySIPFENN beyond its core functionalities, for instance, to train new models on custom datasets
 or to export models in different formats or precisions, you need to install additional dependencies. This can be done

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,3 +26,14 @@ Then, move to the pySIPFENN folder and install in editable (`-e`) mode
 
     cd pySIPFENN
     pip install -e .
+
+# Developer Install
+
+If you want to utilize pySIPFENN beyond its core functionalities, for instance, to train new models on custom datasets
+or to export models in different formats or precisions, you need to install additional dependencies. This can be done
+by installing the `dev` extras with
+
+    pip install pysipfenn[dev]
+
+> Note: If you are using MacOS zsh shell, you may need to enclose the `dev` extras in quotes like 
+> `pip install "pysipfenn[dev]"` or `pip install ".[dev]"`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,13 @@ dependencies = [
     "dnspython",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "coremltools>=6.3",
+    "onnxconverter_common>=1.13.0",
+    "onnxsim==0.4.33"
+]
+
 [project.urls]
 "Research Page" = "https://phaseslab.com/sipfenn"
 "Homepage" = "https://pysipfenn.org"

--- a/pysipfenn/__init__.py
+++ b/pysipfenn/__init__.py
@@ -1,1 +1,2 @@
 from pysipfenn.core.pysipfenn import *
+from pysipfenn.core.modelExporters import *

--- a/pysipfenn/core/modelExporters.py
+++ b/pysipfenn/core/modelExporters.py
@@ -13,14 +13,14 @@ class ONNXExporter:
         self.simplifiedDict = {}
         self.fp16Dict = {}
         self.calculator = calculator
-        if len(self.calculator.loadedModels) == 0:
-            print(f'No models loaded in calculator. '
-                  f'Reloading models into ONNX: {self.calculator.network_list_available}')
-            with resources.files('pysipfenn.modelsSIPFENN') as modelPath:
-                for net in tqdm(self.calculator.network_list_available):
-                    self.calculator.loadedModels.update({
-                        net: onnx.load(f'{modelPath}/{net}.onnx')
-                    })
+        #if len(self.calculator.loadedModels) == 0:
+        #    print(f'No models loaded in calculator. '
+        #          f'Reloading models into ONNX: {self.calculator.network_list_available}')
+        #    with resources.files('pysipfenn.modelsSIPFENN') as modelPath:
+        #        for net in tqdm(self.calculator.network_list_available):
+        #            self.calculator.loadedModels.update({
+        #                net: onnx.load(f'{modelPath}/{net}.onnx')
+        #            })
         print(f'Initialized ONNXExporter with models: {list(self.calculator.loadedModels.keys())}')
 
     def simplify(self, model: str):
@@ -68,3 +68,5 @@ class ONNXExporter:
         for model in tqdm(self.calculator.loadedModels):
             self.export(model)
         print('*****  Done exporting all models!  *****')
+
+

--- a/pysipfenn/core/modelExporters.py
+++ b/pysipfenn/core/modelExporters.py
@@ -1,25 +1,23 @@
 from pysipfenn import Calculator
 import torch
-import coremltools as ct
-from onnxconverter_common import float16
-from onnxsim import simplify
 import onnx
 from tqdm import tqdm
 
+try:
+    import coremltools as ct
+    from onnxconverter_common import float16
+    from onnxsim import simplify
+except ModuleNotFoundError as e:
+    print(f'Could not import {e.name}.\n')
+    print('Dependencies for exporting to CoreML, Torch, and ONNX are not installed by default with pySIPFENN. You need '
+          'to install pySIPFENN in "dev" mode like: pip install -e "pysipfenn[dev]", or like pip install -e ".[dev]" if'
+          'you are cloned it. See pysipfenn.org for more details.')
 
 class ONNXExporter:
     def __init__(self, calculator: Calculator):
         self.simplifiedDict = {}
         self.fp16Dict = {}
         self.calculator = calculator
-        #if len(self.calculator.loadedModels) == 0:
-        #    print(f'No models loaded in calculator. '
-        #          f'Reloading models into ONNX: {self.calculator.network_list_available}')
-        #    with resources.files('pysipfenn.modelsSIPFENN') as modelPath:
-        #        for net in tqdm(self.calculator.network_list_available):
-        #            self.calculator.loadedModels.update({
-        #                net: onnx.load(f'{modelPath}/{net}.onnx')
-        #            })
         assert len(self.calculator.loadedModels) > 0, 'No models loaded in calculator. Nothing to export.'
         print(f'Initialized ONNXExporter with models: {list(self.calculator.loadedModels.keys())}')
 

--- a/pysipfenn/core/modelExporters.py
+++ b/pysipfenn/core/modelExporters.py
@@ -20,10 +20,13 @@ class ONNXExporter:
     (2) simplify the models using ONNX optimizer, and (3) convert them to FP16 precision, cutting the size in half.
 
     Args:
-        calculator: A calculator object with loaded models.
+        calculator: A calculator object with loaded models that has loaded PyTorch models (happens automatically
+        when the autoLoad argument is kept to its default value of True when initializing the Calculator). During the
+        initialization, the loaded PyTorch models are converted back to ONNX (in memory) to be then either adjusted or
+        persisted to disk.
 
     Attributes:
-        calculator: A calculator object with loaded models.
+        calculator: A calculator object with ONNX loaded models.
         simplifiedDict: A dictionary of models that have been simplified.
         fp16Dict: A dictionary of models that have been converted to FP16.
     """

--- a/pysipfenn/core/modelExporters.py
+++ b/pysipfenn/core/modelExporters.py
@@ -13,6 +13,7 @@ except ModuleNotFoundError as e:
     print('Dependencies for exporting to CoreML, Torch, and ONNX are not installed by default with pySIPFENN. You need '
           'to install pySIPFENN in "dev" mode like: pip install -e "pysipfenn[dev]", or like pip install -e ".[dev]" if'
           'you are cloned it. See pysipfenn.org for more details.')
+    raise e
 
 
 class ONNXExporter:

--- a/pysipfenn/core/modelExporters.py
+++ b/pysipfenn/core/modelExporters.py
@@ -13,7 +13,6 @@ except ModuleNotFoundError as e:
     print('Dependencies for exporting to CoreML, Torch, and ONNX are not installed by default with pySIPFENN. You need '
           'to install pySIPFENN in "dev" mode like: pip install -e "pysipfenn[dev]", or like pip install -e ".[dev]" if'
           'you are cloned it. See pysipfenn.org for more details.')
-    raise e
 
 
 class ONNXExporter:

--- a/pysipfenn/core/modelExporters.py
+++ b/pysipfenn/core/modelExporters.py
@@ -1,0 +1,70 @@
+from pysipfenn import Calculator
+import torch
+import coremltools as ct
+from onnxconverter_common import float16
+from onnxsim import simplify
+import onnx
+from tqdm import tqdm
+from importlib import resources
+
+
+class ONNXExporter:
+    def __init__(self, calculator: Calculator):
+        self.simplifiedDict = {}
+        self.fp16Dict = {}
+        self.calculator = calculator
+        if len(self.calculator.loadedModels) == 0:
+            print(f'No models loaded in calculator. '
+                  f'Reloading models into ONNX: {self.calculator.network_list_available}')
+            with resources.files('pysipfenn.modelsSIPFENN') as modelPath:
+                for net in tqdm(self.calculator.network_list_available):
+                    self.calculator.loadedModels.update({
+                        net: onnx.load(f'{modelPath}/{net}.onnx')
+                    })
+        print(f'Initialized ONNXExporter with models: {list(self.calculator.loadedModels.keys())}')
+
+    def simplify(self, model: str):
+        print(f'Simplifying {model}')
+        loadedModel = self.calculator.loadedModels[model]
+        # Simplify
+        onnx_model_simp, check = simplify(loadedModel)
+        assert check, "Simplified ONNX model could not be validated"
+        self.calculator.loadedModels[model] = onnx_model_simp
+        self.simplifiedDict[model] = True
+        print(f'--> Simplified {model}', flush=True)
+
+    def simplifyAll(self):
+        for model in tqdm(self.calculator.loadedModels):
+            self.simplify(model)
+        print('*****  Done simplifying all models!  *****')
+
+    def toFP16(self, model: str):
+        print(f'Converting {model} to FP16')
+        loadedModel = self.calculator.loadedModels[model]
+        # Convert to FP16
+        onnx_model_fp16 = float16.convert_float_to_float16(loadedModel)
+        self.calculator.loadedModels[model] = onnx_model_fp16
+        self.fp16Dict[model] = True
+        print(f'--> Converted {model} to FP16', flush=True)
+
+    def toFP16All(self):
+        for model in tqdm(self.calculator.loadedModels):
+            self.toFP16(model)
+        print('*****  Done converting all models to FP16!  *****')
+
+    def export(self, model: str):
+        print(f'Exporting {model} to ONNX')
+        loadedModel = self.calculator.loadedModels[model]
+        name = f"{model}"
+        if self.simplifiedDict[model]:
+            name += '_simplified'
+        if self.fp16Dict[model]:
+            name += '_fp16'
+        name += '.onnx'
+        onnx.save(loadedModel, name)
+        print(f'--> Exported as {name}', flush=True)
+
+    def exportAll(self):
+        for model in tqdm(self.calculator.loadedModels):
+            self.export(model)
+        print('*****  Done exporting all models!  *****')

--- a/pysipfenn/core/pysipfenn.py
+++ b/pysipfenn/core/pysipfenn.py
@@ -55,13 +55,19 @@ class Calculator:
     """
 
     def __init__(self,
-                 autoLoad: bool = True):
-
+                 autoLoad: bool = True,
+                 verbose: bool = True):
+        if verbose:
+            print('*********  Initializing pySIPFENN Calculator  **********')
         # dictionary with all model information
         with resources.files('pysipfenn.modelsSIPFENN').joinpath('models.json').open('r') as f:
+            if verbose:
+                print(f'Loading model definitions from: {f.name}')
             self.models = json.load(f)
         # networks list
         self.network_list = list(self.models.keys())
+        if verbose:
+            print(f'Found {len(self.network_list)} network definitions in models.json')
         # network names
         self.network_list_names = [self.models[net]['name'] for net in self.network_list]
         self.network_list_available = []
@@ -71,15 +77,19 @@ class Calculator:
         if autoLoad:
             print(f'Loading all available models (autoLoad=True)')
             self.loadModels()
+        else:
+            print(f'Skipping model loading (autoLoad=False)')
 
         self.toRun = []
         self.descriptorData = []
         self.predictions = []
         self.inputFiles = []
-        print(f'*********  PySIPFENN Successfully Initialized  **********')
+        if verbose:
+            print(f'*********  pySIPFENN Successfully Initialized  **********')
 
     def __str__(self):
-        printOut = f'PySIPFENN Calculator Object. Version: {__version__}\n'
+        '''Prints the status of the Calculator object.'''
+        printOut = f'pySIPFENN Calculator Object. Version: {__version__}\n'
         printOut += f'Models are located in:\n{resources.files("pysipfenn.modelsSIPFENN")}\n{"-" * 80}\n'
         printOut += f'Loaded Networks: {list(self.loadedModels.keys())}\n'
         if len(self.inputFiles) > 0:

--- a/pysipfenn/tests/test_ModelExporters.py
+++ b/pysipfenn/tests/test_ModelExporters.py
@@ -1,0 +1,82 @@
+import unittest
+import pytest
+import os
+import pysipfenn
+
+# Skip the tests if we're in GitHub Actions and the models haven't been fetched yet
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true" and os.getenv("MODELS_FETCHED") != "true"
+
+
+class TestExporters(unittest.TestCase):
+    '''Test all model exporting features that can operate on the Calculator object. Note that this will require
+    the models to be downloaded and the environment variable MODELS_FETCHED to be set to true if running in GitHub
+    Actions.'''
+    def setUp(self):
+        '''Initialise the Calculator object for testing.'''
+        self.c = pysipfenn.Calculator()
+        self.assertIsNotNone(self.c)
+
+    def testInit(self):
+        '''Test that the Calculator object is initialised correctly.'''
+        self.assertEqual(self.c.predictions, [])
+        self.assertEqual(self.c.toRun, [])
+        self.assertEqual(self.c.descriptorData, [])
+        self.assertEqual(self.c.inputFiles, [])
+
+    @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test depends on the ONNX network files")
+    def testModelsLoaded(self):
+        '''Test that the models are loaded correctly.'''
+        assert self.c.loadedModels.__len__() > 0, 'No models loaded in calculator. Nothing to export.'
+        self.assertEqual(set(self.c.network_list_available), set(self.c.loadedModels.keys()))
+
+    @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test depends on the ONNX network files")
+    def testONNXSimplify(self):
+        '''Test that the ONNX simplification works with all models with no errors.'''
+        self.onnxexp = pysipfenn.ONNXExporter(self.c)
+        assert self.onnxexp.calculator == self.c
+        assert self.onnxexp.simplifiedDict == {model: False for model in self.c.loadedModels.keys()}
+
+        self.onnxexp.simplifyAll()
+        assert self.onnxexp.simplifiedDict == {model: True for model in self.c.loadedModels.keys()}
+
+    @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test depends on the ONNX network files")
+    def testONNXFP16(self):
+        '''Test that the ONNX FP16 conversion works with all models with no errors.'''
+        self.onnxexp = pysipfenn.ONNXExporter(self.c)
+        assert self.onnxexp.calculator == self.c
+        assert self.onnxexp.fp16Dict == {model: False for model in self.c.loadedModels.keys()}
+
+        self.onnxexp.toFP16All()
+        assert self.onnxexp.fp16Dict == {model: True for model in self.c.loadedModels.keys()}
+
+    @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test depends on the ONNX network files")
+    def testONNXExport(self):
+        '''Test that the ONNX export works with all models with no errors. For two of the models, the export will
+        also simplify or convert to FP16 to check that it gets correctly encoded in the exported file name.'''
+        self.onnxexp = pysipfenn.ONNXExporter(self.c)
+        assert self.onnxexp.calculator == self.c
+
+        self.onnxexp.simplify('SIPFENN_Krajewski2020_NN9')
+        self.onnxexp.toFP16('SIPFENN_Krajewski2020_NN24')
+
+        self.onnxexp.exportAll()
+
+    @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test depends on the ONNX network files")
+    def testTorchExport(self):
+        '''Test that the PyTorch export works with all models with no errors. Please note that if you are using
+        custom descriptors, you will need to add them to the exporter definition in pysipfenn/core/modelExporters.py.'''
+        self.torchexp = pysipfenn.TorchExporter(self.c)
+        assert self.torchexp.calculator == self.c
+
+        self.torchexp.exportAll()
+
+    @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test depends on the ONNX network files")
+    def testCoreMLExport(self):
+        '''Test that the CoreML export works with all models with no errors. Please note that if you are using
+        custom descriptors, you will need to add them to the exporter definition in pysipfenn/core/modelExporters.py.'''
+        self.coremlexp = pysipfenn.CoreMLExporter(self.c)
+        assert self.coremlexp.calculator == self.c
+
+        self.coremlexp.exportAll()
+
+

--- a/pysipfenn/tests/test_ModelExporters.py
+++ b/pysipfenn/tests/test_ModelExporters.py
@@ -23,6 +23,21 @@ class TestExporters(unittest.TestCase):
         self.assertEqual(self.c.descriptorData, [])
         self.assertEqual(self.c.inputFiles, [])
 
+    def testExceptions1(self):
+        '''Test that the exceptions are raised correctly by the exporters when Calculator is empty. Regardless of the
+        model presence, it will skip the automatic loading of models to pretend it is a fresh install.'''
+        c = pysipfenn.Calculator(autoLoad=False)
+
+        with self.assertRaises(AssertionError,
+                               msg='ONNXExporter did not raise an AssertionError on empty Calculator'):
+            onnxexp = pysipfenn.ONNXExporter(c)
+        with self.assertRaises(AssertionError,
+                               msg='TorchExporter did not raise an AssertionError on empty Calculator'):
+            torchexp = pysipfenn.TorchExporter(c)
+        with self.assertRaises(AssertionError,
+                               msg='CoreMLExporter did not raise an AssertionError on empty Calculator'):
+            coremlexp = pysipfenn.CoreMLExporter(c)
+
     @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test depends on the ONNX network files")
     def testModelsLoaded(self):
         '''Test that the models are loaded correctly.'''

--- a/pysipfenn/tests/test_pysipfenn.py
+++ b/pysipfenn/tests/test_pysipfenn.py
@@ -71,7 +71,7 @@ class TestCore(unittest.TestCase):
 
         with self.subTest(msg='Test Calculator printout after predictions'):
             printOut = str(self.c)
-            self.assertIn('PySIPFENN Calculator Object', printOut)
+            self.assertIn('pySIPFENN Calculator Object', printOut)
             self.assertIn('Models are located in', printOut)
             self.assertIn('Loaded Networks', printOut)
             self.assertIn('Last files selected as input', printOut)
@@ -206,7 +206,7 @@ class TestCore(unittest.TestCase):
         '''Test that the Calculator.__str__() method returns the correcttly formatted string after being initialized
         but before predictions'''
         printOut = str(self.c)
-        self.assertIn('PySIPFENN Calculator Object', printOut)
+        self.assertIn('pySIPFENN Calculator Object', printOut)
         self.assertIn('Models are located in', printOut)
         self.assertIn('Loaded Networks', printOut)
 


### PR DESCRIPTION
- This PR introduces the `modelExporters` module with 3 Exporter classes, allowing conversion and saving of the loaded models (including ones modified within pySIPFENN transfer learning runs) into ONNX, PyTorch, and CoreML formats.
- The `ONNXExporter` also allows for model conversion to FP16 precision, lowering the size by a factor of 2, as well as model simplification with the ONNX optimizer toolset.